### PR TITLE
feat: implemented multithreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,14 @@ pip install .
 # Process a single file
 efemel process config.py --out output
 
-# Process multiple files with glob patterns
+# Process multiple files with glob patterns (uses all CPU cores by default)
 efemel process "src/**/*.py" --out exports
 
 # Process files relative to a specific directory
 efemel process "**/*.py" --cwd /path/to/project --out output
+
+# Control parallelism with --workers option
+efemel process "**/*.py" --out output --workers 2
 ```
 
 ### Real-world Example
@@ -170,17 +173,18 @@ Extract dictionary variables from Python files.
 - `--out OUTPUT_DIR` - Directory to write JSON files (required)
 - `--cwd DIRECTORY` - Working directory for file operations (optional)
 - `--env ENVIRONMENT` - Environment for dynamic imports (e.g., `prod`, `staging`) (optional)
+- `--workers NUMBER` - Number of parallel workers (default: CPU thread count) (optional)
 
 **Examples:**
 ```bash
 # Single file
 efemel process config.py --out output
 
-# All Python files recursively
+# All Python files recursively (uses all CPU cores)
 efemel process "**/*.py" --out output
 
-# Files in specific directory
-efemel process "src/config/*.py" --out exported
+# Files in specific directory with 2 workers
+efemel process "src/config/*.py" --out exported --workers 2
 
 # Process relative to different directory
 efemel process "*.py" --cwd /path/to/configs --out output
@@ -188,8 +192,8 @@ efemel process "*.py" --cwd /path/to/configs --out output
 # Process with production environment
 efemel process "config/**/*.py" --out output --env prod
 
-# Process with staging environment and custom working directory
-efemel process "**/*.py" --cwd /app/configs --out exports --env staging
+# Process with staging environment and custom working directory (single-threaded)
+efemel process "**/*.py" --cwd /app/configs --out exports --env staging --workers 1
 ```
 
 ### `efemel info`

--- a/efemel/cli.py
+++ b/efemel/cli.py
@@ -1,6 +1,5 @@
-"""
-CLI entry point for efemel.
-"""
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import click
 
@@ -8,6 +7,8 @@ from efemel.process import process_py_file
 from efemel.readers.local import LocalReader
 from efemel.transformers.json import JSONTransformer
 from efemel.writers.local import LocalWriter
+
+DEFAULT_WORKERS = os.cpu_count() or 1
 
 
 @click.group()
@@ -32,7 +33,13 @@ def info():
 @click.option("--out", "-o", required=True, help="Output directory for JSON files")
 @click.option("--env", "-e", help="Environment for processing (default: none)")
 @click.option("--cwd", "-c", help="Working directory to search for files (default: current)")
-def process(file_pattern, out, cwd, env):
+@click.option(
+  "--workers",
+  "-w",
+  default=DEFAULT_WORKERS,
+  help=f"Number of parallel workers (default: {DEFAULT_WORKERS})",
+)
+def process(file_pattern, out, cwd, env, workers):
   """Process Python files and extract public dictionary variables to JSON.
 
   FILE_PATTERN: Glob pattern to match Python files (e.g., "**/*.py")
@@ -42,17 +49,41 @@ def process(file_pattern, out, cwd, env):
   transformer = JSONTransformer()
   writer = LocalWriter(out, reader.original_cwd)
 
-  for file_path in reader.read(file_pattern):
-    public_dicts = process_py_file(file_path, env)
+  # Collect all files to process
+  files_to_process = list(reader.read(file_pattern))
 
-    if not public_dicts:
-      click.echo(f"ℹ️  No public dictionaries found in {file_path}")
+  if not files_to_process:
+    click.echo("No files found matching the pattern.")
+    return
 
-    transformed_data = transformer.transform(public_dicts)
+  def process_single_file(file_path):
+    """Process a single file and return results."""
+    try:
+      # Always create output file, even if no dictionaries found
+      public_dicts = process_py_file(file_path, env) or {}
+      transformed_data = transformer.transform(public_dicts)
+      output_file = writer.write(transformed_data, file_path.with_suffix(transformer.suffix))
 
-    output_file = writer.write(transformed_data, file_path.with_suffix(transformer.suffix))
+      return file_path, output_file, f"Processed: {reader.cwd / file_path} → {output_file}"
 
-    click.echo(f"Processed: {reader.cwd / file_path} → {output_file}")
+    except Exception as e:
+      raise Exception(f"Error processing {file_path}: {str(e)}") from e
+
+  # Process files in parallel
+  click.echo(f"Processing {len(files_to_process)} files with {workers} workers...")
+
+  with ThreadPoolExecutor(max_workers=workers) as executor:
+    # Submit all tasks
+    future_to_file = {executor.submit(process_single_file, file_path): file_path for file_path in files_to_process}
+    # Process completed tasks as they finish
+    processed_count = 0
+    for future in as_completed(future_to_file):
+      file_path, output_file, message = future.result()
+      click.echo(message)
+      if output_file:
+        processed_count += 1
+
+  click.echo(f"✅ Completed processing {processed_count}/{len(files_to_process)} files.")
 
 
 def main():


### PR DESCRIPTION
This pull request introduces parallel processing capabilities to the `efemel` CLI tool, allowing users to specify the number of workers for file processing. The changes include updates to the CLI implementation, documentation, and the addition of a default worker count based on the CPU thread count.

### CLI Enhancements:
* Introduced a new `--workers` option in the `process` command to specify the number of parallel workers, with a default value set to the CPU thread count (`DEFAULT_WORKERS`). [[1]](diffhunk://#diff-de0f2600e6a42ac7b348702e57bd981acb52d415245acea28131a08442e9d630R11-R12) [[2]](diffhunk://#diff-de0f2600e6a42ac7b348702e57bd981acb52d415245acea28131a08442e9d630L35-R42)
* Refactored the `process` function to use `ThreadPoolExecutor` for parallel file processing, improving performance for large file sets. Added error handling for individual file processing tasks.

### Documentation Updates:
* Updated `README.md` to include examples and explanations for the new `--workers` option, highlighting its default behavior and usage scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R196)

### Codebase Improvements:
* Added imports for `ThreadPoolExecutor` and `os` to support parallel processing and dynamic worker count determination.
* Defined `DEFAULT_WORKERS` as a constant, calculated using `os.cpu_count()` with a fallback to 1 if the CPU count is unavailable.