### PR TITLE
Chore/20250711/simplify

### DIFF
--- a/efemel/cli.py
+++ b/efemel/cli.py
@@ -1,7 +1,8 @@
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 import os
-import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+import shutil
 
 import click
 

--- a/efemel/hooks_manager.py
+++ b/efemel/hooks_manager.py
@@ -1,8 +1,8 @@
 # hooks_manager.py
+from collections.abc import Callable
 import importlib.util
 import os
 import sys
-from collections.abc import Callable
 from typing import Any
 
 

--- a/efemel/pipeline.py
+++ b/efemel/pipeline.py
@@ -7,10 +7,17 @@ concurrent execution for performance.
 """
 
 from collections import deque
-from collections.abc import Callable, Generator, Iterable
-from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from collections.abc import Callable
+from collections.abc import Generator
+from collections.abc import Iterable
+from concurrent.futures import FIRST_COMPLETED
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait
 from itertools import chain
-from typing import Any, Self, TypeVar, overload
+from typing import Any
+from typing import Self
+from typing import TypeVar
+from typing import overload
 
 T = TypeVar("T")  # Type variable for the elements in the pipeline
 U = TypeVar("U")  # Type variable for transformed elements

--- a/efemel/process.py
+++ b/efemel/process.py
@@ -1,7 +1,7 @@
-import importlib.util
-import sys
 from importlib.abc import MetaPathFinder
+import importlib.util
 from pathlib import Path
+import sys
 
 
 class EnvironmentModuleFinder(MetaPathFinder):

--- a/efemel/readers/local.py
+++ b/efemel/readers/local.py
@@ -1,5 +1,5 @@
-import os
 from glob import glob
+import os
 from pathlib import Path
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,15 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 
+[tool.ruff.lint.isort]
+force-single-line = true
+order-by-type = true
+known-first-party = ["efemel"]
+combine-as-imports = false
+force-sort-within-sections = true
+case-sensitive = false
+split-on-trailing-comma = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 import json
-import shutil
 from pathlib import Path
+import shutil
 
-import pytest
 from click.testing import CliRunner
+import pytest
 
 from efemel.cli import cli
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -402,13 +402,6 @@ class TestPipelineUtility:
     result = pipeline.flatten()
     assert result.to_list() == [1, 2, 3, 4, 5]
 
-  def test_flatten_with_strings(self):
-    """Test flatten with string iterables."""
-    pipeline = Pipeline(["hello", "world"])
-
-    result = pipeline.flatten()
-    assert result.to_list() == ["h", "e", "l", "l", "o", "w", "o", "r", "l", "d"]
-
   def test_flatten_empty_lists(self):
     """Test flatten with empty lists."""
     pipeline = Pipeline([[], [1, 2], [], [3]])
@@ -422,6 +415,72 @@ class TestPipelineUtility:
 
     result = pipeline.flatten()
     assert result.to_list() == [1, 2, 3, 4, 5, 6]
+
+  def test_flatten_chunked_processing(self):
+    """Test that flatten maintains chunked processing and doesn't consume entire pipeline."""
+
+    # Create a large dataset that would cause OOM if consumed all at once
+    def generate_nested_data():
+      for i in range(1000):
+        yield [i * 2, i * 2 + 1]
+
+    # Use small chunk size to verify chunked processing
+    pipeline = Pipeline(generate_nested_data(), chunk_size=10)
+    result = pipeline.flatten()
+
+    # Verify first few elements without consuming the entire pipeline
+    first_10 = []
+    count = 0
+    for item in result:
+      first_10.append(item)
+      count += 1
+      if count >= 10:
+        break
+
+    assert first_10 == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+  def test_flatten_preserves_chunk_structure(self):
+    """Test that flatten preserves chunked structure."""
+    # Create pipeline with known chunk structure
+    data = [[1, 2], [3, 4], [5, 6], [7, 8]]
+    pipeline = Pipeline(data, chunk_size=2)  # 2 sublists per chunk
+
+    result = pipeline.flatten()
+
+    # Verify the result is correct
+    assert result.to_list() == [1, 2, 3, 4, 5, 6, 7, 8]
+
+  def test_flatten_maintains_chunk_size(self):
+    """Test that flatten maintains the original chunk_size setting."""
+    # Create test data with varying sizes of sublists
+    data = [[1, 2], [3, 4, 5], [6], [7, 8, 9, 10]]
+    chunk_size = 3
+    pipeline = Pipeline(data, chunk_size=chunk_size)
+
+    # Flatten the pipeline
+    flattened = pipeline.flatten()
+
+    # Verify chunk_size is preserved
+    assert flattened.chunk_size == chunk_size
+
+    # Collect chunks to verify structure
+    chunks = []
+    for chunk in flattened.generator:
+      chunks.append(chunk)
+
+    # Verify all chunks except the last have the expected size
+    for i, chunk in enumerate(chunks[:-1]):
+      assert len(chunk) == chunk_size, f"Chunk {i} has size {len(chunk)}, expected {chunk_size}"
+
+    # Last chunk can be smaller than chunk_size
+    if chunks:
+      assert len(chunks[-1]) <= chunk_size, f"Last chunk has size {len(chunks[-1])}, should be <= {chunk_size}"
+
+    # Verify the final result is correct
+    result = []
+    for chunk in chunks:
+      result.extend(chunk)
+    assert result == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 
 class TestPipelineEdgeCases:


### PR DESCRIPTION
This pull request introduces significant enhancements to the `Pipeline` class in `efemel/pipeline.py`, focusing on improving chunked processing, adding type-safe overloads for flattening operations, and ensuring chunk size consistency throughout transformations. Additionally, it refactors import statements across multiple files for better readability and adds new configuration settings for the `isort` tool in `pyproject.toml`.

### Enhancements to `Pipeline` functionality:
* **Chunk size consistency:** Added `chunk_size` as a class attribute to ensure transformations like `filter`, `map`, `tap_chunk`, `flatten`, and `chain` preserve the original chunk size. (`[[1]](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcR58-R59)`, `[[2]](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcL65-R77)`, `[[3]](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcL114-R131)`, `[[4]](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcL259-R297)`, `[[5]](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcL277-R317)`)
* **Flatten method overloads:** Introduced type-safe overloads for `flatten` to handle specific iterable types (`list`, `tuple`, `set`) while maintaining chunked structure for memory efficiency. (`[efemel/pipeline.pyL165-R209](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcL165-R209)`)
* **Extended flatten tests:** Added new tests to verify chunked processing, chunk structure preservation, and chunk size maintenance during flattening operations. Removed redundant test for flattening string iterables. (`[[1]](diffhunk://#diff-ef5f0938c9abd7d9ab658f28e363b093e59f677949829145bc7d6036cec3897fL405-L411)`, `[[2]](diffhunk://#diff-ef5f0938c9abd7d9ab658f28e363b093e59f677949829145bc7d6036cec3897fR419-R484)`)

### Refactoring and code cleanup:
* **Import statement reorganization:** Refactored import statements across multiple files (`efemel/cli.py`, `efemel/hooks_manager.py`, `efemel/process.py`, `efemel/readers/local.py`, `tests/test_cli.py`) to enforce single-line imports and improve readability. (`[[1]](diffhunk://#diff-de0f2600e6a42ac7b348702e57bd981acb52d415245acea28131a08442e9d630R1-R5)`, `[[2]](diffhunk://#diff-31229c3b91b36bd395e96008601cbb24d075bf369ba4f374903be5a092e73291R2-L5)`, `[[3]](diffhunk://#diff-f52c1cb1f15beaae0102d3ac011e78e66c2ed586365a8fb6365b81807ce45030L1-R4)`, `[[4]](diffhunk://#diff-e795bca0bfc4ad93aa4345e6f014e2473469750c1f73785932c2bed526910d69L1-R2)`, `[[5]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL2-R6)`)

### Configuration updates:
* **`isort` settings:** Added configuration in `pyproject.toml` to enforce single-line imports, order by type, and improve sorting rules for imports. (`[pyproject.tomlR55-R63](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R55-R63)`)