### PR TITLE
fix: more list comprehension and correct pipeline initialisation

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -364,7 +364,7 @@ class TestPipelineUtility:
     # Data should be unchanged
     assert result.to_list() == [1, 2, 3, 4, 5]
 
-  def test_apply_single_function(self):
+  def test_apply_function(self):
     """Test apply with single function."""
     pipeline = Pipeline([1, 2, 3, 4, 5])
 
@@ -373,27 +373,6 @@ class TestPipelineUtility:
 
     result = pipeline.apply(double_pipeline)
     assert result.to_list() == [2, 4, 6, 8, 10]
-
-  def test_apply_multiple_functions(self):
-    """Test apply with multiple functions."""
-    pipeline = Pipeline([1, 2, 3, 4, 5])
-
-    def double_pipeline(p):
-      return p.map(lambda x: x * 2)
-
-    def filter_even(p):
-      return p.filter(lambda x: x % 2 == 0)
-
-    result = pipeline.apply(double_pipeline, filter_even)
-    assert result.to_list() == [2, 4, 6, 8, 10]
-
-  def test_apply_no_functions(self):
-    """Test apply with no functions."""
-    pipeline = Pipeline([1, 2, 3, 4, 5])
-
-    # Should return the same pipeline
-    result = pipeline.apply()
-    assert result.to_list() == [1, 2, 3, 4, 5]
 
   def test_flatten_basic(self):
     """Test basic flatten operation."""


### PR DESCRIPTION
This pull request refactors the `Pipeline` class in `efemel/pipeline.py` to simplify its implementation and improve readability while maintaining functionality. Key changes include replacing nested loops with generator expressions, updating type hints for better clarity, and streamlining methods for single-function application. Corresponding test cases in `tests/test_pipeline.py` have been updated to reflect these changes.

### Pipeline Refactoring:

* **Simplified Method Implementations**:
  - Replaced nested loops with generator expressions in methods like `__iter__`, `to_list`, and `flatten` for improved readability and efficiency. (Faea2baaL99R99, Faea2baaL192R192)
  - Streamlined `filter` and `map` methods by directly using generator expressions for chunk processing. (Faea2baaL141R141)
  - Updated `tap` and `each` methods to use `deque` for efficient consumption of elements. (Faea2baaL172R172)

* **Improved Type Hints**:
  - Added `Union` type hints to support multiple types for `source` in the constructor and `flatten` method. ([efemel/pipeline.pyL16-R19](diffhunk://#diff-41232c54a631af00f8efcf69ef8dd52bad12518bf2f443aaf36b3888182d22dcL16-R19), Faea2baaL172R172)

* **Refactored `apply` Method**:
  - Simplified `apply` to handle only a single transformation function, removing support for multiple functions. (Faea2baaL301R301)

### Test Updates:

* **Updated Test Cases**:
  - Removed tests for multi-function application and no-function application in `apply`, reflecting the refactored method's new behavior.
  - Renamed test for single-function application to `test_apply_function` for clarity.